### PR TITLE
api_version_2 is not required anymore.

### DIFF
--- a/ContinueWithVipps.class.php
+++ b/ContinueWithVipps.class.php
@@ -124,7 +124,6 @@ class ContinueWithVipps {
         }
 
         if (is_array($scope)) $scope = join(' ',$scope);
-        $scope ="api_version_2 $scope"; // Necessary to keep trucking after feb 28 2021
 
         if (!is_array($sessiondata)) $sessiondata = array();
         $sessiondata['action'] = $action;


### PR DESCRIPTION
The scope `api_version_2` is not needed anymore and should not be used.