### PR TITLE
Replace custom html buttons with web component

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ You can use the framework of this plugin to implement other signed actions, such
 
 ## Shortcodes
 
-* `[login-with-vipps text="Log in with Vipps" application="wordpress"]` - This will print out a *Login with Vipps MobilePay* button that will log you into the given application, which by default can be either WordPress or WooCommerce.
-* `[continue-with-vipps text="Continue with Vipps" application="wordpress"]` - This is the same, except for a different default text.
+* `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either Wordpress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
+* `[continue-with-vipps application="wordpress"]` - This is the same, except for a different default text verb.
 
 ## Customizing the plugin
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can use the framework of this plugin to implement other signed actions, such
 
 ## Shortcodes
 
-* `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either Wordpress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
+* `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either WordPress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
 * `[continue-with-vipps application="wordpress"]` - This is the same, except for a different default text verb.
 
 ## Customizing the plugin

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -136,6 +136,15 @@ class VippsLogin {
         // This is for confirming - with Vipps - an already existing user.
         add_action('continue_with_vipps_confirm_login', array($this, 'continue_with_vipps_confirm_login'), 10, 2);
         add_action('continue_with_vipps_error_confirm_login', array($this, 'continue_with_vipps_error_confirm_login'), 10, 4);
+
+        // Register web component button, enqueued frontend and backend. LP 2026-06-04
+        wp_register_script(
+            "vipps-button-webcomponent",
+            "https://checkout.vipps.no/checkout-button/v1/vipps-checkout-button.js",
+            [],
+            VIPPS_LOGIN_VERSION,
+            ['in_footer' => true, 'strategy'  => 'async'],
+        );
     }
 
     // Scripts used to make the 'login' button work; they use Ajax. IOK 2019-10-14
@@ -151,9 +160,11 @@ class VippsLogin {
         wp_enqueue_style('login-with-vipps',plugins_url('css/login-with-vipps.css',__FILE__),array(),filemtime(dirname(__FILE__) . "/css/login-with-vipps.css"), 'all');
         $logo = plugins_url("img/vmp-logo.png", __FILE__);
         wp_add_inline_style('login-with-vipps', ".woocommerce-MyAccount-navigation ul li.woocommerce-MyAccount-navigation-link--vipps a::before { background-image: url('{$logo}'); }");
+        wp_enqueue_script("vipps-button-webcomponent");
     }
 
 
+    // for all login and registration related forms. LP 2026-06-04
     public function login_enqueue_scripts() {
         if (!static::is_active()) return;
         $options = get_option('vipps_login_settings');
@@ -162,6 +173,7 @@ class VippsLogin {
         wp_enqueue_script('login-with-vipps',plugins_url('js/login-with-vipps.js',__FILE__),array('jquery'),filemtime(dirname(__FILE__) . "/js/login-with-vipps.js"), 'true');
         wp_localize_script('login-with-vipps', 'vippsLoginConfig', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
         wp_enqueue_style('login-with-vipps',plugins_url('css/login-with-vipps.css',__FILE__),array(),filemtime(dirname(__FILE__) . "/css/login-with-vipps.css"), 'all');
+        wp_enqueue_script("vipps-button-webcomponent");
     }
 
 
@@ -790,7 +802,7 @@ class VippsLogin {
     public function login_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button();
+        $this->login_button('wordpress', ['verb' => 'login']);
         $this->move_continue_button_over_login_form();
     }
 
@@ -804,7 +816,6 @@ class VippsLogin {
     public function login_button($application='wordpress', $button_args=[]) {
         // The "application" should only contain letters, numbers and hyphens. IOK 2024-11-26
         $application = preg_replace("![^a-zA-Z0-9-_]!", "", $application);
-
 
         ob_start();
         ?>
@@ -837,6 +848,9 @@ class VippsLogin {
         $args['type'] = 'button';
         $args['brand'] = strtolower($login_method);
         $args['compact'] = 'false';
+
+        // Only support verbs 'login' and 'continue'. LP 2026-06-04
+        if (!in_array($args['verb'], ['continue', 'login'])) $args['verb'] = 'continue';
 
         if ('store' === $args['language']) $args['language'] = $this->get_store_language();
 

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -393,7 +393,7 @@ class VippsLogin {
         return $language;
      }
 
-    public function get_store_language() {
+    public function get_site_language() {
         global $TRP_LANGUAGE; // TranslatePress IOK 2025-11-06
 
         $language = substr(get_bloginfo('language'),0,2);
@@ -497,7 +497,7 @@ class VippsLogin {
     * Store in the class because we need it in render.php for some data we don't store in the block attributes. LP 2026-02-04 */
     public function login_with_vipps_block_config() {
         $login_method = strtolower($this->get_login_method());
-        $store_language = $this->get_store_language();
+        $store_language = $this->get_site_language();
         if ($store_language === 'se') {
             $store_language = 'sv';
         }
@@ -835,7 +835,7 @@ class VippsLogin {
     public function web_component_button($args = []) {
         $login_method = $this->get_login_method();
         $default_args = [
-            'language' => $this->get_store_language(),
+            'language' => $this->get_site_language(),
             'variant' => 'primary',
             'rounded' => 'false',
             'verb' => 'continue',
@@ -851,7 +851,7 @@ class VippsLogin {
         // Only support verbs 'login' and 'continue'. LP 2026-06-04
         if (!in_array($args['verb'], ['continue', 'login'])) $args['verb'] = 'continue';
 
-        if ('store' === $args['language']) $args['language'] = $this->get_store_language();
+        if ('store' === $args['language']) $args['language'] = $this->get_site_language();
 
         $html = <<<EOF
 <vipps-mobilepay-button

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -792,7 +792,7 @@ class VippsLogin {
         ob_start();
         ?> 
             <span class='continue-with-vipps-wrapper inline'>
-            <?php $this->login_button_html($args['application'], $button_args); ?>
+            <?php $this->continue_button_html($args['application'], $button_args); ?>
             </span>
             <?php
         return ob_get_clean();
@@ -802,18 +802,24 @@ class VippsLogin {
     public function login_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button_html('wordpress', ['verb' => 'login']);
+        $this->login_button_html('wordpress');
         $this->move_continue_button_over_login_form();
     }
 
     public function register_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button_html();
+        $this->continue_button_html('wordpress');
         $this->move_continue_button_over_login_form();
     }
 
-    public function login_button_html($application='wordpress', $button_args=[]) {
+    // Return a "login" button
+    public function login_button_html($application='wordpress', $button_args=['verb'=>'login']) {
+       $button_args['verb'] = 'login';
+       return $this->continue_button_html($application, $button_args);
+    }
+    // Main helper for the "Continue with ..." button.
+    public function continue_button_html($application='wordpress', $button_args=[]) {
         // The "application" should only contain letters, numbers and hyphens. IOK 2024-11-26
         $application = preg_replace("![^a-zA-Z0-9-_]!", "", $application);
 
@@ -829,7 +835,7 @@ class VippsLogin {
         $button_html = apply_filters('continue_with_vipps_login_button_html', ob_get_clean(), $application, '');
 
         // The new filter when changing from custom button html to web component. LP 2026-06-04
-        echo apply_filters('continue_with_vipps_login_button', $button_html, $application, $button_args);
+        echo apply_filters('continue_with_vipps_button_html', $button_html, $application, $button_args);
     }
 
     public function web_component_button($args = []) {

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -757,17 +757,30 @@ class VippsLogin {
     }
     public function log_in_with_vipps_shortcode($atts, $content, $tag) {
         if (!is_array($atts)) $atts = array();
-        if (!isset($atts['text'])) $atts['text'] = __('Log in with', 'login-with-vipps');
+        if (!isset($atts['verb'])) $atts['verb'] = 'login';
         return $this->continue_with_vipps_shortcode($atts,$content,$tag);
     }
-    public function continue_with_vipps_shortcode($atts,$content,$tag) {
-        $args = shortcode_atts(array('application'=>'wordpress', 'text'=>__('Continue with', 'login-with-vipps')), $atts);
-        $text = esc_html($args['text']);
-        $application = $args['application'];
+    public function continue_with_vipps_shortcode($atts, $content, $tag) {
+        $args = shortcode_atts([
+            'application' => 'wordpress',
+            'language' => 'store',
+            'variant' => 'primary',
+            'rounded' => 'false',
+            'verb' => 'continue',
+            'stretched' => 'false',
+            'branded' => 'true',
+        ], $atts);
+
+        // Separate web component button args from attributes. LP 2026-06-04
+        $button_args = [];
+        foreach(['language', 'variant', 'rounded', 'verb', 'stretched', 'branded'] as $key) {
+            if (isset($args[$key])) $button_args[$key] = $args[$key];
+        }
+
         ob_start();
         ?> 
             <span class='continue-with-vipps-wrapper inline'>
-            <?php $this->login_button($application); ?>
+            <?php $this->login_button($args['application'], $button_args); ?>
             </span>
             <?php
         return ob_get_clean();
@@ -824,6 +837,9 @@ class VippsLogin {
         $args['type'] = 'button';
         $args['brand'] = strtolower($login_method);
         $args['compact'] = 'false';
+
+        if ('store' === $args['language']) $args['language'] = $this->get_store_language();
+
         error_log('LP args: ' . print_r($args, true));
         $html = <<<EOF
 <vipps-mobilepay-button

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -783,7 +783,7 @@ class VippsLogin {
             'branded' => 'true',
         ], $atts);
 
-        // Separate web component button args from attributes. LP 2026-06-04
+        // The actual button web component attributes. LP 2026-06-04
         $button_args = [];
         foreach(['language', 'variant', 'rounded', 'verb', 'stretched', 'branded'] as $key) {
             if (isset($args[$key])) $button_args[$key] = $args[$key];
@@ -792,7 +792,7 @@ class VippsLogin {
         ob_start();
         ?> 
             <span class='continue-with-vipps-wrapper inline'>
-            <?php $this->login_button($args['application'], $button_args); ?>
+            <?php $this->login_button_html($args['application'], $button_args); ?>
             </span>
             <?php
         return ob_get_clean();
@@ -802,18 +802,18 @@ class VippsLogin {
     public function login_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button('wordpress', ['verb' => 'login']);
+        $this->login_button_html('wordpress', ['verb' => 'login']);
         $this->move_continue_button_over_login_form();
     }
 
     public function register_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button();
+        $this->login_button_html();
         $this->move_continue_button_over_login_form();
     }
 
-    public function login_button($application='wordpress', $button_args=[]) {
+    public function login_button_html($application='wordpress', $button_args=[]) {
         // The "application" should only contain letters, numbers and hyphens. IOK 2024-11-26
         $application = preg_replace("![^a-zA-Z0-9-_]!", "", $application);
 
@@ -826,11 +826,10 @@ class VippsLogin {
             </div>
             <?php 
         // legacy filter. Use continue_with_vipps_login_button instead. LP 2026-06-04
-        $button = apply_filters('continue_with_vipps_login_button_html', ob_get_clean(), $application, '');
-        error_log('LP button: ' . print_r($button, true));
+        $button_html = apply_filters('continue_with_vipps_login_button_html', ob_get_clean(), $application, '');
 
         // The new filter when changing from custom button html to web component. LP 2026-06-04
-        echo apply_filters('continue_with_vipps_login_button', $button, $application, $button_args);
+        echo apply_filters('continue_with_vipps_login_button', $button_html, $application, $button_args);
     }
 
     public function web_component_button($args = []) {
@@ -854,7 +853,6 @@ class VippsLogin {
 
         if ('store' === $args['language']) $args['language'] = $this->get_store_language();
 
-        error_log('LP args: ' . print_r($args, true));
         $html = <<<EOF
 <vipps-mobilepay-button
     type="{$args['type']}"
@@ -905,7 +903,7 @@ EOF;
                     var tops = theform.parentNode;
                     tops.insertBefore(me, theform); 
                 }
-                me.style.display = 'block';
+                me.classList.add('login-form');
             }
         </script>
             <?php

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -767,7 +767,7 @@ class VippsLogin {
         ob_start();
         ?> 
             <span class='continue-with-vipps-wrapper inline'>
-            <?php $this->login_button_html($text, $application); ?>
+            <?php $this->login_button($application); ?>
             </span>
             <?php
         return ob_get_clean();
@@ -777,38 +777,69 @@ class VippsLogin {
     public function login_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->wp_login_button(__('Log in with', 'login-with-vipps'));
+        $this->login_button();
         $this->move_continue_button_over_login_form();
     }
+
     public function register_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->wp_login_button(__('Continue with', 'login-with-vipps'));
+        $this->login_button();
         $this->move_continue_button_over_login_form();
     }
-    public function wp_login_button($text, $application='wordpress') {
-        ?>
-            <div id='continue-with-vipps-wrapper' class='continue-with-vipps-wrapper'>
-            <?php $this->login_button_html($text, $application); ?>
-            </div>
-            <?php 
-    }
 
-    // The HTML for this button. IOK 2019-10-14
-    public function login_button_html($text, $application) {
-        $login_method = $this->get_login_method();
-        $logo = $this->get_transparent_logo();
-        $bg = $this->get_background_class();
+    public function login_button($application='wordpress', $button_args=[]) {
         // The "application" should only contain letters, numbers and hyphens. IOK 2024-11-26
         $application = preg_replace("![^a-zA-Z0-9-_]!", "", $application);
+
+
         ob_start();
         ?>
-            <a href='javascript:login_with_vipps("<?php echo $application; ?>");' class="button vipps-orange vipps-button continue-with-vipps <?php echo esc_attr($bg);?>" title="<?php echo esc_attr(sprintf("%s %s", $text, $login_method)); ?>"><?php echo esc_html($text);?> <img
-            alt="<?php echo esc_attr(sprintf(__('Log in without password using %1$s', 'login-with-vipps'), $login_method)); ?>" src="<?php echo esc_attr($logo); ?>">!</a>
-            <?php
-        echo apply_filters('continue_with_vipps_login_button_html', ob_get_clean(), $application, $text);
+            <div id='continue-with-vipps-wrapper' class='continue-with-vipps-wrapper'>
+                <a href='javascript:login_with_vipps("<?php echo $application; ?>");' class="button vipps-orange vipps-button continue-with-vipps">
+                    <?php echo $this->web_component_button($button_args); ?>
+                </a>
+            </div>
+            <?php 
+        // legacy filter. Use continue_with_vipps_login_button instead. LP 2026-06-04
+        $button = apply_filters('continue_with_vipps_login_button_html', ob_get_clean(), $application, '');
+        error_log('LP button: ' . print_r($button, true));
+
+        // The new filter when changing from custom button html to web component. LP 2026-06-04
+        echo apply_filters('continue_with_vipps_login_button', $button, $application, $button_args);
     }
 
+    public function web_component_button($args = []) {
+        $login_method = $this->get_login_method();
+        $default_args = [
+            'language' => $this->get_store_language(),
+            'variant' => 'primary',
+            'rounded' => 'false',
+            'verb' => 'continue',
+            'stretched' => 'false',
+            'branded' => 'true',
+        ];
+        $args = wp_parse_args($args, $default_args);
+        // these are static for now. LP 2026-06-04
+        $args['type'] = 'button';
+        $args['brand'] = strtolower($login_method);
+        $args['compact'] = 'false';
+        error_log('LP args: ' . print_r($args, true));
+        $html = <<<EOF
+<vipps-mobilepay-button
+    type="{$args['type']}"
+    brand="{$args['brand']}"
+    language="{$args['language']}"
+    variant="{$args['variant']}"
+    rounded="{$args['rounded']}"
+    verb="{$args['verb']}"
+    stretched="{$args['stretched']}"
+    compact="{$args['compact']}"
+    branded="{$args['branded']}"
+></vipps-mobilepay-button>
+EOF;
+        return apply_filters('continue_with_vipps_web_component_html', $html, $args);
+    }
 
     // The logo for the login button, depending on the login method.
     public function get_transparent_logo() {
@@ -831,16 +862,6 @@ class VippsLogin {
         return plugins_url('img/vmp-logo.png', __FILE__);
     }
 
-    // The background for the login button, depending on the login method.
-    public function get_background_class() {
-        $method = $this->get_login_method();
-        if ($method == 'MobilePay') {
-            return 'mobilepay-background';
-        }
-        if ($method == 'Vipps') {
-            return 'vipps-background';
-        }
-    }
 
     // The login form does not have any action that runs right before the form, where we want to be. So we cheat, rewriting the page using javascript. IOK 2019-10-14
     public function move_continue_button_over_login_form() {

--- a/VippsLogin.class.php
+++ b/VippsLogin.class.php
@@ -802,7 +802,7 @@ class VippsLogin {
     public function login_form_continue_with_vipps () {
         $options = get_option('vipps_login_settings');
         if (!$options['login_page']) return;
-        $this->login_button_html('wordpress');
+        $this->login_button_html("ignored", 'wordpress');
         $this->move_continue_button_over_login_form();
     }
 
@@ -813,8 +813,9 @@ class VippsLogin {
         $this->move_continue_button_over_login_form();
     }
 
-    // Return a "login" button
-    public function login_button_html($application='wordpress', $button_args=['verb'=>'login']) {
+    // Return a "login" button. The first argument is currently ignored - it used to be a possibly non-standard text, which 
+    // Vipps MobilePay no longer supports. IOK 2026-06-08
+    public function login_button_html($text="", $application='wordpress', $button_args=['verb'=>'login']) {
        $button_args['verb'] = 'login';
        return $this->continue_button_html($application, $button_args);
     }

--- a/VippsWooLogin.class.php
+++ b/VippsWooLogin.class.php
@@ -282,7 +282,7 @@ class VippsWooLogin{
         ob_start();
         ?>
             <div class='continue-with-vipps-wrapper center-block <?php echo $type; ?>'>
-            <?php VippsLogin::instance()->login_button_html(__('Continue with', 'login-with-vipps'), 'woocommerce'); ?>
+            <?php VippsLogin::instance()->continue_button_html('woocommerce'); ?>
             </div>
             <?php
         echo apply_filters('continue_with_vipps_cart_button', ob_get_clean(), $type);

--- a/blocks/login-with-vipps-blocks.php
+++ b/blocks/login-with-vipps-blocks.php
@@ -51,21 +51,5 @@ add_action('enqueue_block_assets', function () {
         return;
     }
 
-    wp_enqueue_script(
-        "vipps-button-webcomponent",
-        "https://checkout.vipps.no/checkout-button/v1/vipps-checkout-button.js",
-        [],
-        VIPPS_LOGIN_VERSION,
-        ['in_footer' => true, 'strategy'  => 'async'],
-    );
-});
-// web component for frontend. LP 2026-02-25
-add_action('wp_enqueue_scripts', function () {
-    wp_enqueue_script(
-        "vipps-button-webcomponent",
-        "https://checkout.vipps.no/checkout-button/v1/vipps-checkout-button.js",
-        [],
-        VIPPS_LOGIN_VERSION,
-        ['in_footer' => true, 'strategy'  => 'async'],
-    );
+    wp_enqueue_script("vipps-button-webcomponent");
 });

--- a/css/login-with-vipps.css
+++ b/css/login-with-vipps.css
@@ -25,30 +25,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/* Styles for wp-login.php */
-#continue-with-vipps-wrapper, .continue-with-vipps-wrapper.center-block {
- text-align:center;
- display: block;
- padding: 0.5rem 0;
-}
-#continue-with-vipps-wrapper {
- margin: 20px;
-}
-
-#continue-with-vipps-wrapper .button.continue-with-vipps {
- margin: 0 auto;
- width: 100%;
- height: 48px; 
- line-height: 48px;
-} 
-
 /* And the rest */
-.continue-with-vipps-wrapper.center-block .button.continue-with-vipps {
- margin: 0 auto;
- width: 100%;
+.continue-with-vipps-wrapper.center-block {
+    display: flex;
+    justify-content: center;
 }
 .continue-with-vipps-wrapper {
- display:inline-block;
+    display: block;
+}
+.continue-with-vipps-wrapper.login-form {
+    display: flex;
+    justify-content: center;
 }
 .continue-with-vipps-wrapper a.button.continue-with-vipps img {
     max-width: 6rem;

--- a/css/login-with-vipps.css
+++ b/css/login-with-vipps.css
@@ -37,29 +37,11 @@ SOFTWARE.
     display: flex;
     justify-content: center;
 }
-.continue-with-vipps-wrapper a.button.continue-with-vipps img {
-    max-width: 6rem;
-    margin:0px 2px;
-    display:inline;
-    height: 2ex;
-    vertical-align: text-bottom;
-}
-.continue-with-vipps-wrapper a.button.continue-with-vipps:hover img {
-    opacity: 0.9;
-}
-.continue-with-vipps-wrapper a.button.continue-with-vipps.disabled img {
-    opacity: 0.7;
-}
 .continue-with-vipps-wrapper a.button.continue-with-vipps {
- display: inline-block;
- color: #fff;
+ display: inline;
  border: 0;
  padding:0;
- font-size: 22px;
- height: 48px;
  line-height: 48px;
- font-weight: 400;
- text-align:center;
  cursor: pointer;
  box-sizing: border-box;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -60,8 +60,8 @@ Already registered users can link their current accounts when signing in with Vi
 You can use the framework of this plugin to implement other solutions that require verified users, without actually requiring login. For example, you might create a system for having users sign their comments with Vipps MobilePay so as to avoid spam issues.
 
 == Shortcodes ==
- * `[login-with-vipps text="Log in with Vipps (or MobilePay)" application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either Wordpress or WooCommerce.
- * `[continue-with-vipps text="Continue with Vipps" application="wordpress"]` - This is the same, except for a different default text
+ * `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either Wordpress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
+ * `[continue-with-vipps application="wordpress"]` - This is the same, except for a different default text verb.
 
 == Installation ==
 **If you are an existing Vipps MobilePay customer**, log onto the Vipps MobilePay portal https://portal.vippsmobilepay.com and retreive your API keys that you will need to install Login with Vipps MobilePay

--- a/readme.txt
+++ b/readme.txt
@@ -60,7 +60,7 @@ Already registered users can link their current accounts when signing in with Vi
 You can use the framework of this plugin to implement other solutions that require verified users, without actually requiring login. For example, you might create a system for having users sign their comments with Vipps MobilePay so as to avoid spam issues.
 
 == Shortcodes ==
- * `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either Wordpress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
+ * `[login-with-vipps application="wordpress"]` - This will print out a Login with Vipps button that will log you into the given application, which by default can be either WordPress or WooCommerce. Uses this web component and supports the parameters: https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/.
  * `[continue-with-vipps application="wordpress"]` - This is the same, except for a different default text verb.
 
 == Installation ==


### PR DESCRIPTION
Replaces all buttons including the shortcodes. Shortcodes now support all web component params.
New filter (old filter kept as legacy) for filtering the button html, with includes the web component args.

NOTE: there is a bug when displaying multiple of these web components on the same page with different language argument, everyone will display the same language. According to https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/, its a bug on the component 

> Note also that there is a bug in the library, and it currently only renders one language per page.